### PR TITLE
Call the marc record service generator when there is a catkey or previous catkey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ sudo: false
 language: ruby
 cache: bundler
 
+before_install:
+  - gem update --system
+  - gem --version
+
 script: bundle exec rake ci
 
 after_success:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'okcomputer' # for monitoring
 gem 'rubocop', group: [:development, :test]
 gem 'rubocop-rspec', group: [:development, :test]
 
+gem 'faraday'
+
 group :test do
   gem 'rspec-rails'
   gem 'equivalent-xml'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 
 gem 'base_indexer', '~> 4.0'
-gem 'discovery-indexer', '~> 3.0', '>= 3.1.1'
+gem 'discovery-indexer', '~> 3.0', '>= 3.1.2'
 
 gem 'responders', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       safe_yaml (~> 1.0.0)
     deep_merge (1.1.1)
     diff-lcs (1.2.5)
-    discovery-indexer (3.1.1)
+    discovery-indexer (3.1.2)
       nokogiri
       rest-client
       retries
@@ -238,7 +238,7 @@ GEM
     sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (2.3.1)
+    stanford-mods (2.4.0)
       activesupport
       mods (~> 2.0, >= 2.0.2)
     term-ansicolor (1.4.0)
@@ -272,7 +272,7 @@ DEPENDENCIES
   capistrano-rvm
   config
   coveralls
-  discovery-indexer (~> 3.0, >= 3.1.1)
+  discovery-indexer (~> 3.0, >= 3.1.2)
   dlss-capistrano
   equivalent-xml
   faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ DEPENDENCIES
   discovery-indexer (~> 3.0, >= 3.1.1)
   dlss-capistrano
   equivalent-xml
+  faraday
   honeybadger (~> 2.0)
   jbuilder (~> 2.0)
   okcomputer
@@ -286,4 +287,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.14.4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = 'public, max-age=3600'
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
 PURL_URL: https://purl.stanford.edu
 SKIP_CATKEY_CHECK:
   - SEARCHWORKSPREVIEW
+DOR_SERVICES_URL: http://user:password@localhost:9292/v1

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,6 @@ SOLR_TARGETS:
   MYSOLR:
     target1:
       url: http://solr-cloud/mysolr
+  SEARCHWORKSPREVIEW:
+    target1:
+      url: http://solr-cloud/searchworkspreview

--- a/spec/fixtures/xml_fixtures.rb
+++ b/spec/fixtures/xml_fixtures.rb
@@ -178,6 +178,227 @@ module XmlFixtures
     xml
   end
 
+  def item_image_xml_with_catkey
+    <<-xml
+    <publicObject id="druid:zz999zz9999" published="2015-02-26T14:10:51-08:00">
+      <identityMetadata>
+        <sourceId source="hoover">2012c34_3_a</sourceId>
+        <objectId>druid:zz999zz9999</objectId>
+        <objectCreator>DOR</objectCreator>
+        <objectLabel>Item Title</objectLabel>
+        <objectType>item</objectType>
+        <adminPolicy>druid:aa111bb2222</adminPolicy>
+        <otherId name="label"/>
+        <otherId name="catkey">12345</otherId>
+        <otherId name="uuid">080ac28c-5159-11e3-815a-0050569b3c3c</otherId>
+        <tag>Process : Content Type : Image</tag>
+        <tag>Project : Collection</tag>
+        <tag>Registered By : blalbrit</tag>
+        <tag>Remediated By : 4.17.1</tag>
+      </identityMetadata>
+      <contentMetadata objectId="zz999zz9999" type="image">
+        <resource id="zz999zz9999_1" sequence="1" type="image">
+          <label>Image 1</label>
+          <file id="a24.jp2" mimetype="image/jp2" size="3674159">
+            <imageData width="5334" height="3660"/>
+          </file>
+        </resource>
+        <resource id="zz999zz9999_2" sequence="2" type="image">
+          <label>Image 2</label>
+          <file id="a25.jp2" mimetype="image/jp2" size="3706126">
+            <imageData width="5508" height="3576"/>
+          </file>
+        </resource>
+        <resource id="zz999zz9999_3" sequence="3" type="image">
+          <label>Image 3</label>
+          <file id="a26.jp2" mimetype="image/jp2" size="2543862">
+            <imageData width="3450" height="3918"/>
+          </file>
+        </resource>
+        <resource id="zz999zz9999_4" sequence="4" type="image">
+          <label>Image 4</label>
+          <file id="a27.jp2" mimetype="image/jp2" size="3370403">
+            <imageData width="4950" height="3618"/>
+          </file>
+        </resource>
+        <resource id="zz999zz9999_5" sequence="5" type="image">
+          <label>Image 5</label>
+          <file id="a28.jp2" mimetype="image/jp2" size="3471135">
+            <imageData width="4950" height="3726"/>
+          </file>
+        </resource>
+      </contentMetadata>
+      <rightsMetadata>
+        <access type="discover">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <access type="read">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <use>
+          <human type="useAndReproduction"/>
+          <human type="creativeCommons"/>
+          <machine type="creativeCommons"/>
+        </use>
+        <copyright>
+          <human type="copyright">Copyright</human>
+        </copyright>
+      </rightsMetadata>
+      <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="info:fedora/druid:zz999zz9999">
+          <fedora:isMemberOf rdf:resource="info:fedora/druid:oo000oo0000"/>
+          <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:oo000oo0000"/>
+        </rdf:Description>
+      </rdf:RDF>
+      <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+        <dc:title>DC title</dc:title>
+        <dc:contributor>DC contributor</dc:contributor>
+        <dc:type>StillImage</dc:type>
+        <dc:date>1909-1915</dc:date>
+        <dc:relation type="collection">DC relation Collection title</dc:relation>
+      </oai_dc:dc>
+      <ReleaseDigest/>
+      <thumb>zz999zz9999/a24.jp2</thumb>
+    </publicObject>
+    xml
+  end
+
+  def item_image_xml_previous_catkeys
+    <<-xml
+    <publicObject id="druid:zz999zz9999" published="2015-02-26T14:10:51-08:00">
+      <identityMetadata>
+        <sourceId source="hoover">2012c34_3_a</sourceId>
+        <objectId>druid:zz999zz9999</objectId>
+        <objectCreator>DOR</objectCreator>
+        <objectLabel>Item Title</objectLabel>
+        <objectType>item</objectType>
+        <adminPolicy>druid:aa111bb2222</adminPolicy>
+        <otherId name="label"/>
+        <otherId name="previous_catkey">000</otherId>
+        <otherId name="previous_catkey">999</otherId>
+        <otherId name="uuid">080ac28c-5159-11e3-815a-0050569b3c3c</otherId>
+        <tag>Process : Content Type : Image</tag>
+        <tag>Project : Collection</tag>
+        <tag>Registered By : blalbrit</tag>
+        <tag>Remediated By : 4.17.1</tag>
+      </identityMetadata>
+      <contentMetadata objectId="zz999zz9999" type="image">
+        <resource id="zz999zz9999_1" sequence="1" type="image">
+          <label>Image 1</label>
+          <file id="a24.jp2" mimetype="image/jp2" size="3674159">
+            <imageData width="5334" height="3660"/>
+          </file>
+        </resource>
+      </contentMetadata>
+      <rightsMetadata>
+        <access type="discover">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <access type="read">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <use>
+          <human type="useAndReproduction"/>
+          <human type="creativeCommons"/>
+          <machine type="creativeCommons"/>
+        </use>
+        <copyright>
+          <human type="copyright">Copyright</human>
+        </copyright>
+      </rightsMetadata>
+      <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="info:fedora/druid:zz999zz9999">
+          <fedora:isMemberOf rdf:resource="info:fedora/druid:oo000oo0000"/>
+          <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:oo000oo0000"/>
+        </rdf:Description>
+      </rdf:RDF>
+      <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+        <dc:title>DC title</dc:title>
+        <dc:contributor>DC contributor</dc:contributor>
+        <dc:type>StillImage</dc:type>
+        <dc:date>1909-1915</dc:date>
+        <dc:relation type="collection">DC relation Collection title</dc:relation>
+      </oai_dc:dc>
+      <ReleaseDigest/>
+      <thumb>zz999zz9999/a24.jp2</thumb>
+    </publicObject>
+    xml
+  end
+
+  def item_image_xml_previous_and_current_catkey
+    <<-xml
+    <publicObject id="druid:zz999zz9999" published="2015-02-26T14:10:51-08:00">
+      <identityMetadata>
+        <sourceId source="hoover">2012c34_3_a</sourceId>
+        <objectId>druid:zz999zz9999</objectId>
+        <objectCreator>DOR</objectCreator>
+        <objectLabel>Item Title</objectLabel>
+        <objectType>item</objectType>
+        <adminPolicy>druid:aa111bb2222</adminPolicy>
+        <otherId name="label"/>
+        <otherId name="previous_catkey">000</otherId>
+        <otherId name="catkey">12345</otherId>
+        <otherId name="uuid">080ac28c-5159-11e3-815a-0050569b3c3c</otherId>
+        <tag>Process : Content Type : Image</tag>
+        <tag>Project : Collection</tag>
+        <tag>Registered By : blalbrit</tag>
+        <tag>Remediated By : 4.17.1</tag>
+      </identityMetadata>
+      <contentMetadata objectId="zz999zz9999" type="image">
+        <resource id="zz999zz9999_1" sequence="1" type="image">
+          <label>Image 1</label>
+          <file id="a24.jp2" mimetype="image/jp2" size="3674159">
+            <imageData width="5334" height="3660"/>
+          </file>
+        </resource>
+      </contentMetadata>
+      <rightsMetadata>
+        <access type="discover">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <access type="read">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <use>
+          <human type="useAndReproduction"/>
+          <human type="creativeCommons"/>
+          <machine type="creativeCommons"/>
+        </use>
+        <copyright>
+          <human type="copyright">Copyright</human>
+        </copyright>
+      </rightsMetadata>
+      <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="info:fedora/druid:zz999zz9999">
+          <fedora:isMemberOf rdf:resource="info:fedora/druid:oo000oo0000"/>
+          <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:oo000oo0000"/>
+        </rdf:Description>
+      </rdf:RDF>
+      <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+        <dc:title>DC title</dc:title>
+        <dc:contributor>DC contributor</dc:contributor>
+        <dc:type>StillImage</dc:type>
+        <dc:date>1909-1915</dc:date>
+        <dc:relation type="collection">DC relation Collection title</dc:relation>
+      </oai_dc:dc>
+      <ReleaseDigest/>
+      <thumb>zz999zz9999/a24.jp2</thumb>
+    </publicObject>
+    xml
+  end
+
   def item_file_xml
     <<-xml
     <publicObject id="druid:zz999zz9999" published="2015-02-26T14:10:51-08:00">

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,14 +1,28 @@
 ##
 # Helper methods used for tests
 module Helpers
-  def stub_solr
+
+  def dor_services_stub
+    stub_request(:post, "http://localhost:9292/v1/objects/druid:zz999zz9999/update_marc_record")
+          .with(:headers => {'Accept'=>'*/*', 'Content-Length'=>'0'})
+          .to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  def post_stub_solr
     stub_request(:post, /solr/)
-      .to_return(status: 200, body: '')
+          .with(body: /^.*<add/)
+          .to_return(status: 200, body: '')
+  end
+
+  def delete_stub_solr
+    stub_request(:post, /solr/)
+          .with(body: /^.*<delete>/)
+          .to_return(status: 200, body: '')
   end
 
   def stub_purl_and_solr(druid, purl_xml, mods_xml)
     stub_purl(druid, purl_xml, mods_xml)
-    stub_solr
+    post_stub_solr
   end
 
   def stub_purl(druid, purl_xml, mods_xml)

--- a/spec/sw_indexer_engine_spec.rb
+++ b/spec/sw_indexer_engine_spec.rb
@@ -9,15 +9,19 @@ describe SwIndexerEngine do
 
   describe 'index' do
     context 'for targets that should not be skipped checking' do
-      it 'calls solr delete for the index' do
+      it 'calls solr delete for the index and calls dor-services 856 generation call' do
         expect(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
+        dor_services_stub = stub_request(:post, "http://localhost:9292/v1/objects/druid:zz999zz9999/update_marc_record").
+                with(:headers => {'Accept'=>'*/*', 'Content-Length'=>'0'}).
+                to_return(:status => 200, :body => "", :headers => {})
         stub_purl('druid:zz999zz9999', item_image_xml, item_image_mods)
         stub_collection('oo000oo0000', coll_image_xml)
         solr_stub = stub_request(:post, /solr/)
           .with(body: /^.*<delete><id>druid:zz999zz9999/)
           .to_return(status: 200, body: '')
         subject.index(item_pid, 'MYSOLR' => true)
-        expect(solr_stub).to have_been_requested
+        expect(solr_stub).to have_been_requested.once
+        expect(dor_services_stub).to have_been_requested.once
       end
       it 'proceeds with indexing' do
         stub_purl_and_solr('druid:zz999zz9999', item_image_xml, item_image_mods)

--- a/spec/sw_indexer_engine_spec.rb
+++ b/spec/sw_indexer_engine_spec.rb
@@ -4,49 +4,60 @@ describe SwIndexerEngine do
   include XmlFixtures
   let(:smods_rec) { Stanford::Mods::Record.new }
   let(:item_pid) { 'druid:zz999zz9999' }
-  let(:ckey_doc) { double('PurlThing', catkey: '12345') }
-  let(:no_ckey_doc) { double('PurlThing', catkey: nil) }
   before :each do
     @dor_services_stub = dor_services_stub
     @delete_solr_stub = delete_stub_solr
     @post_solr_stub = post_stub_solr
-    stub_purl('druid:zz999zz9999', item_image_xml, item_image_mods)
     stub_collection('oo000oo0000', coll_image_xml)
   end
 
   describe 'index' do
     context 'for targets that should be checked for catkeys' do
-      # NOTE: The MYSOLR target is will have catkey checks applied
+      # NOTE: The MYSOLR target has catkey checks applied
       let(:catkey_check_target) { 'MYSOLR' }
+      it 'indexes and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
+        stub_purl(item_pid, item_image_xml, item_image_mods)
+        subject.index(item_pid, catkey_check_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).not_to have_been_requested
+        expect(@post_solr_stub).to have_been_requested.once
+      end
+      it 'indexes and calls dor-services 856 generation call for a record with no catkey but with previous catkeys' do
+        stub_purl(item_pid, item_image_xml_previous_catkeys, item_image_mods)
+        subject.index(item_pid, catkey_check_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).to have_been_requested.once
+        expect(@post_solr_stub).to have_been_requested.once
+      end
       it 'does not index but instead calls solr delete and calls dor-services 856 generation call for a record with a catkey' do
-        allow(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
+        stub_purl(item_pid, item_image_xml_with_catkey, item_image_mods)
         subject.index(item_pid, catkey_check_target => true)
         expect(@delete_solr_stub).to have_been_requested.once
         expect(@dor_services_stub).to have_been_requested.once
         expect(@post_solr_stub).not_to have_been_requested
       end
-      it 'indexes and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
-        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
+      it 'does not index but instead calls solr delete and calls dor-services 856 generation call for a record with both previous and current catkeys' do
+        stub_purl(item_pid, item_image_xml_previous_and_current_catkey, item_image_mods)
         subject.index(item_pid, catkey_check_target => true)
-        expect(@delete_solr_stub).not_to have_been_requested
-        expect(@dor_services_stub).not_to have_been_requested
-        expect(@post_solr_stub).to have_been_requested.once
+        expect(@delete_solr_stub).to have_been_requested.once
+        expect(@dor_services_stub).to have_been_requested.once
+        expect(@post_solr_stub).not_to have_been_requested
       end
     end
     context 'for targets that should NOT be checked for catkeys' do
       # NOTE: The SEARCHWORKSPREVIEW target is configured to skip all catkey checks
       let(:no_catkey_check_target) { 'SEARCHWORKSPREVIEW' }
       it 'indexes and does not call solr delete nor dor-services 856 generation call for a record even with a catkey' do
-        allow(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
-        expect(subject).not_to receive(:purl_model)
+        stub_purl(item_pid, item_image_xml_with_catkey, item_image_mods)
+        expect(subject).not_to receive(:purl)
         subject.index(item_pid, no_catkey_check_target => true)
         expect(@delete_solr_stub).not_to have_been_requested
         expect(@dor_services_stub).not_to have_been_requested
         expect(@post_solr_stub).to have_been_requested.once
       end
       it 'indexes and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
-        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
-        expect(subject).not_to receive(:purl_model)
+        stub_purl(item_pid, item_image_xml, item_image_mods)
+        expect(subject).not_to receive(:purl)
         subject.index(item_pid, no_catkey_check_target => true)
         expect(@delete_solr_stub).not_to have_been_requested
         expect(@dor_services_stub).not_to have_been_requested
@@ -57,7 +68,7 @@ describe SwIndexerEngine do
       # NOTE: The BOGUS target is not configured in test.yml
       let(:bogus_target) { 'BOGUS' }
       it 'does not index and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
-        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
+        stub_purl(item_pid, item_image_xml, item_image_mods)
         subject.index(item_pid, bogus_target => true)
         expect(@delete_solr_stub).not_to have_been_requested
         expect(@dor_services_stub).not_to have_been_requested

--- a/spec/sw_indexer_engine_spec.rb
+++ b/spec/sw_indexer_engine_spec.rb
@@ -6,38 +6,62 @@ describe SwIndexerEngine do
   let(:item_pid) { 'druid:zz999zz9999' }
   let(:ckey_doc) { double('PurlThing', catkey: '12345') }
   let(:no_ckey_doc) { double('PurlThing', catkey: nil) }
+  before :each do
+    @dor_services_stub = dor_services_stub
+    @delete_solr_stub = delete_stub_solr
+    @post_solr_stub = post_stub_solr
+    stub_purl('druid:zz999zz9999', item_image_xml, item_image_mods)
+    stub_collection('oo000oo0000', coll_image_xml)
+  end
 
   describe 'index' do
-    context 'for targets that should not be skipped checking' do
-      it 'calls solr delete for the index and calls dor-services 856 generation call' do
-        expect(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
-        dor_services_stub = stub_request(:post, "http://localhost:9292/v1/objects/druid:zz999zz9999/update_marc_record").
-                with(:headers => {'Accept'=>'*/*', 'Content-Length'=>'0'}).
-                to_return(:status => 200, :body => "", :headers => {})
-        stub_purl('druid:zz999zz9999', item_image_xml, item_image_mods)
-        stub_collection('oo000oo0000', coll_image_xml)
-        solr_stub = stub_request(:post, /solr/)
-          .with(body: /^.*<delete><id>druid:zz999zz9999/)
-          .to_return(status: 200, body: '')
-        subject.index(item_pid, 'MYSOLR' => true)
-        expect(solr_stub).to have_been_requested.once
-        expect(dor_services_stub).to have_been_requested.once
+    context 'for targets that should be checked for catkeys' do
+      # NOTE: The MYSOLR target is will have catkey checks applied
+      let(:catkey_check_target) { 'MYSOLR' }
+      it 'does not index but instead calls solr delete and calls dor-services 856 generation call for a record with a catkey' do
+        allow(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
+        subject.index(item_pid, catkey_check_target => true)
+        expect(@delete_solr_stub).to have_been_requested.once
+        expect(@dor_services_stub).to have_been_requested.once
+        expect(@post_solr_stub).not_to have_been_requested
       end
-      it 'proceeds with indexing' do
-        stub_purl_and_solr('druid:zz999zz9999', item_image_xml, item_image_mods)
-        stub_collection('oo000oo0000', coll_image_xml)
-
-        expect(subject).not_to receive(:purl_model)
-        expect(subject.index(item_pid, 'SEARCHWORKSPREVIEW' => true)).to be_nil
+      it 'indexes and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
+        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
+        subject.index(item_pid, catkey_check_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).not_to have_been_requested
+        expect(@post_solr_stub).to have_been_requested.once
       end
     end
-    context 'for targets that should be skipped checking' do
-      it 'proceeds with indexing' do
-        stub_purl_and_solr('druid:zz999zz9999', item_image_xml, item_image_mods)
-        stub_collection('oo000oo0000', coll_image_xml)
-
-        expect(subject).not_to receive(:purl_model).with(item_pid)
-        expect(subject.index(item_pid, 'SEARCHWORKSPREVIEW' => true)).to be_nil
+    context 'for targets that should NOT be checked for catkeys' do
+      # NOTE: The SEARCHWORKSPREVIEW target is configured to skip all catkey checks
+      let(:no_catkey_check_target) { 'SEARCHWORKSPREVIEW' }
+      it 'indexes and does not call solr delete nor dor-services 856 generation call for a record even with a catkey' do
+        allow(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
+        expect(subject).not_to receive(:purl_model)
+        subject.index(item_pid, no_catkey_check_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).not_to have_been_requested
+        expect(@post_solr_stub).to have_been_requested.once
+      end
+      it 'indexes and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
+        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
+        expect(subject).not_to receive(:purl_model)
+        subject.index(item_pid, no_catkey_check_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).not_to have_been_requested
+        expect(@post_solr_stub).to have_been_requested.once
+      end
+    end
+    context 'for a non-configured target' do
+      # NOTE: The BOGUS target is not configured in test.yml
+      let(:bogus_target) { 'BOGUS' }
+      it 'does not index and does not call solr delete nor dor-services 856 generation call for a record with no catkey' do
+        allow(subject).to receive(:purl_model).with(item_pid).and_return(no_ckey_doc)
+        subject.index(item_pid, bogus_target => true)
+        expect(@delete_solr_stub).not_to have_been_requested
+        expect(@dor_services_stub).not_to have_been_requested
+        expect(@post_solr_stub).not_to have_been_requested
       end
     end
   end


### PR DESCRIPTION
fixes #104 

also fix some rails 5 deprecation warnings

...don't forget to do PRs for shared_config updates for sw-indexer environments before deploy

depends on https://github.com/sul-dlss/dor-services-app/issues/73 being completed and deployed first
